### PR TITLE
Add an option to remove dummy dependencies from ucas

### DIFF
--- a/UnrealReZen/Program.cs
+++ b/UnrealReZen/Program.cs
@@ -35,6 +35,9 @@ namespace UnrealReZen
         [Option("mount-point", Required = false, Default = "../../../", HelpText = "Mount point of packed archive")]
         public string MountPoint { get; set; }
 
+        [Option("no-dummy-dep", Required = false, HelpText = "Prevents the creation of a dummy dependency file")]
+        public bool NoDummyDep { get; set; }
+
         [Usage(ApplicationAlias = "UnrealReZen.exe")]
         public static IEnumerable<Example> Examples
         {
@@ -118,7 +121,10 @@ namespace UnrealReZen
             Dependency m = new() { Deps = new DependenciesData { ChunkIDToDependencies = [] }, Files = [] };
             List<string> FilesToRepack = new(Directory.GetFiles(opts.ContentPath, "*", SearchOption.AllDirectories));
             var newContainerID = CryptographyHelpers.RandomUlong();
-            m.Files.Add(new ManifestFile { ChunkID = new FIoChunkID(newContainerID, 0, 0, (byte)EIoChunkType.ContainerHeader), Filepath = Constants.DepFileName });
+            if (!opts.NoDummyDep)
+            {
+                m.Files.Add(new ManifestFile { ChunkID = new FIoChunkID(newContainerID, 0, 0, (byte)EIoChunkType.ContainerHeader), Filepath = Constants.DepFileName });
+            }
             m.Deps.ThisPackageID = newContainerID;
             foreach (var file in FilesToRepack)
             {


### PR DESCRIPTION
My game will crash with the dummy manifest file. It would be great if there is a flag to remove it.

(edit)
I don't know how ucas works and idk if it's actually a dummy file or not. so let me know if there is a better name for the new option. I'll make another commit for it.