### PR TITLE
fix a bug where missing files are ignored

### DIFF
--- a/UnrealReZen/Program.cs
+++ b/UnrealReZen/Program.cs
@@ -125,7 +125,7 @@ namespace UnrealReZen
                 string filename = file.Replace(opts.ContentPath + "\\", "").Replace("\\", "/");
                 Log.Information("Mounting " + Path.GetFileName(filename));
                 var filedata = provider.Files.Values.Where(a => a.Path.Equals(filename, StringComparison.CurrentCultureIgnoreCase));
-                if (filedata == null)
+                if (filedata == null || !filedata.Any())
                 {
                     Log.Warning("Error! Cannot find file " + filename + " in archives.");
                     Log.Fatal("Repack aborted!");


### PR DESCRIPTION
I noticed that UnrealReZen ignored the "file not found" errors. `filedata` was not null but an empty object when the `Where` method failed. So, it should check if `filedata` has actual data or not.