### PR TITLE
Fix compression lookups and zlib output length

### DIFF
--- a/UnrealReZen/Core/Compression/Compressions.cs
+++ b/UnrealReZen/Core/Compression/Compressions.cs
@@ -7,7 +7,7 @@ namespace UnrealReZen.Core.Compression
     public class CompressionUtils
     {
 
-        public static readonly Dictionary<string, Func<byte[], byte[]>> CompressionMethods = new Dictionary<string, Func<byte[], byte[]>>
+        public static readonly Dictionary<string, Func<byte[], byte[]>> CompressionMethods = new(StringComparer.OrdinalIgnoreCase)
         {
             { "None", CompressNone },
             { "Zlib", CompressZlib },
@@ -17,7 +17,7 @@ namespace UnrealReZen.Core.Compression
 
         public static byte[]? Compress(string method, byte[] inputData)
         {
-            if (CompressionMethods.TryGetValue(method.ToLower(), out var compressionFunction))
+            if (CompressionMethods.TryGetValue(method, out var compressionFunction))
             {
                 return compressionFunction(inputData);
             }
@@ -48,7 +48,7 @@ namespace UnrealReZen.Core.Compression
             {
                 throw new Exception($"Zlib compression failed with error code {compressionResult}");
             }
-            return compressedBuffer;
+            return compressedBuffer.AsSpan(0, compressedSize).ToArray();
 
         }
 


### PR DESCRIPTION
## Summary
- use case-insensitive dictionary for compression methods
- return the correct byte length from Zlib compression

## Testing
- `dotnet build UnrealReZen.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff81e148083279fd22d03517c6e2a